### PR TITLE
Use target project configuration when mapping custom fields

### DIFF
--- a/src/main/java/de/cronn/jira/sync/config/JiraSyncConfig.java
+++ b/src/main/java/de/cronn/jira/sync/config/JiraSyncConfig.java
@@ -99,4 +99,11 @@ public class JiraSyncConfig {
 			.findFirst()
 			.orElseThrow(() -> new IllegalArgumentException("Found no project config for '" + sourceProject + "'"));
 	}
+
+    public JiraProjectSync getProjectConfigByTargetProject(JiraProject targetProject) {
+		return getProjects().values().stream()
+				.filter(project -> project.getTargetProject().equals(targetProject.getKey()))
+				.findFirst()
+				.orElseThrow(() -> new IllegalArgumentException("Found no project config for '" + targetProject + "'"));
+    }
 }

--- a/src/main/java/de/cronn/jira/sync/mapping/DefaultFieldMapper.java
+++ b/src/main/java/de/cronn/jira/sync/mapping/DefaultFieldMapper.java
@@ -83,7 +83,7 @@ public class DefaultFieldMapper implements FieldMapper {
 				Map<String, Object> allowedValuesForCustomField = toJira.getAllowedValuesForCustomField(toProject.getKey(), toField.getId());
 				@SuppressWarnings("unchecked")
 				String source = (String) ((Map<String, Object>) sourceValue).get("value");
-				Map<String, Map<String, String>> fieldValueMappings = jiraSyncConfig.getProjectConfigBySourceProject(toProject).getFieldValueMappings();
+				Map<String, Map<String, String>> fieldValueMappings = jiraSyncConfig.getProjectConfigByTargetProject(toProject).getFieldValueMappings();
 				Map<String, String> fieldValueMapping = fieldValueMappings.get(toField.getName());
 				if (source != null && fieldValueMapping != null) {
 					Assert.isTrue(fieldValueMapping.containsValue(source), "found no field value mapping for field " + toField + " with value '" + source + "' ");


### PR DESCRIPTION
Seems like the configuration of source target is used to retrieve custom fields of target project.